### PR TITLE
Add non-functional test for security of endpoints

### DIFF
--- a/backend/test/authorizationTest.py
+++ b/backend/test/authorizationTest.py
@@ -78,15 +78,15 @@ def test_post(endpoint: str, token: str, body={}):
     Parameters:
     endpoint (str): endpoint to test
     token (str): auth token (JWT) for headers
-    body (dict): NOT USED - body for the post request
+    body (dict): body for the post request
     """
     global tests
     tests += 1
     headers = get_header(token)
     url = '{0}{1}'.format(base_url, endpoint)
     data = {}
-    # data['body'] = json.dumps(body)
-    response = requests.post(url, data=data, headers=headers)
+    data['body'] = json.dumps(body)
+    response = requests.post(url, json=data, headers=headers)
     check_if_unauthorized(response, endpoint)
 
 def test_put(endpoint: str, token: str, body={}):
@@ -95,15 +95,15 @@ def test_put(endpoint: str, token: str, body={}):
     Parameters:
     endpoint (str): endpoint to test
     token (str): auth token (JWT) for headers
-    body (dict): NOT USED - body for the post request
+    body (dict): body for the put request
     """
     global tests
     tests += 1
     headers = get_header(token)
     url = '{0}{1}'.format(base_url, endpoint)
     data = {}
-    # data['body'] = json.dumps(body)
-    response = requests.put(url, data=data, headers=headers)
+    data['body'] = json.dumps(body)
+    response = requests.put(url, json=data, headers=headers)
     check_if_unauthorized(response, endpoint)
 
 ######################### Test config #########################
@@ -119,7 +119,6 @@ else:
     logging.getLogger().setLevel(logging.INFO)
 
 ######################### Run tests #########################
-# Note: Body has no effect, I could not get it working
 
 # users
 test_get('/users/{0}'.format(user_id), expired_token)
@@ -140,4 +139,4 @@ logging.info("Total tests run: {}".format(tests))
 if failed > 0:
     logging.error("Tests failed: {0} ❌".format(failed))
 else:
-    logging.info("All tests passed! All are secure. ✅")
+    logging.info("All tests passed! All endpoints are secure. ✅")

--- a/backend/test/authorizationTest.py
+++ b/backend/test/authorizationTest.py
@@ -2,6 +2,7 @@ import json
 import requests
 import logging
 import argparse
+import time
 
 expired_token = "eyJhbGciOiJSUzI1NiIsImtpZCI6ImQxOTI5ZmY0NWM2MDllYzRjNDhlYmVmMGZiMTM5MmMzOTEzMmQ5YTEiLCJ0eXAiOiJKV1QifQ.eyJuYW1lIjoiTnlhIE1lbWVzIiwicGljdHVyZSI6Imh0dHBzOi8vbGg0Lmdvb2dsZXVzZXJjb250ZW50LmNvbS8tRzNfWng5VkZzbUUvQUFBQUFBQUFBQUkvQUFBQUFBQUFBQUEvQU1adXVjay1QSVlOdG4zTG1UZHlIM1hzVEthbTlTQVdSZy9zOTYtYy9waG90by5qcGciLCJpc3MiOiJodHRwczovL3NlY3VyZXRva2VuLmdvb2dsZS5jb20vZGFpbHlkYXNoLTZkOTc5IiwiYXVkIjoiZGFpbHlkYXNoLTZkOTc5IiwiYXV0aF90aW1lIjoxNjA0ODEwOTk2LCJ1c2VyX2lkIjoiVnRVaE1wMmF3YVBIOW1JcmxPSTNVQUR3Z2o3MyIsInN1YiI6IlZ0VWhNcDJhd2FQSDltSXJsT0kzVUFEd2dqNzMiLCJpYXQiOjE2MDQ4MTA5OTYsImV4cCI6MTYwNDgxNDU5NiwiZW1haWwiOiJueWFtZW1lc0BnbWFpbC5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiZmlyZWJhc2UiOnsiaWRlbnRpdGllcyI6eyJnb29nbGUuY29tIjpbIjEwNDk3NTg2MDUwOTcyNjIyNDU2MCJdLCJlbWFpbCI6WyJueWFtZW1lc0BnbWFpbC5jb20iXX0sInNpZ25faW5fcHJvdmlkZXIiOiJnb29nbGUuY29tIn19.not3iRfV3vruiAEkq9j4T4kIypofOIqW0sGw-DNaCbekkKYm7XuFHPP4YEZZD9Um7xyJT-IOzJ3yqW5jhumdjBwxMw72JmZ5hbt7m7OtQgtuwn-9Uxai0-P_6icSdUv1EVeO7apaI611QsxhpNwsq8x-sRQBgbmIfjpdXQ3rvPXTIsAUJirrR2-C-FRWEdbdo0sf63DRn-AUcAGPxHxijJRmE3jxRFQkXI5zRdZXFC-LP4ZjP3TvUg4poEPwM47uFaeBysa0aFQ3HN6wZVVqUpAQdspEOfRcq5NnOg2vX5ggB54DMtikK3UsDsj3vlGOrZsjQ7E2En3SCButv0ZUBw"
 user_id = 'RPeq88j3J7YPusoSsRcHg5rXepn1'
@@ -10,19 +11,46 @@ base_url = "http://18.224.140.58:3000"
 failed = 0
 tests = 0
 
-def get_header(token: str):
+######################### Test methods #########################
+# Write new tests below this section
+
+def get_header(token: str) -> dict:
+    """Get the HTTP header for a given token
+
+    Parameters:
+    token (str): auth token (JWT)
+
+    Returns:
+    dict: the headers for the HTTP request
+    """
     return {'Content-Type': 'application/json',
            'Authorization': 'Bearer {0}'.format(token)}
 
 def check_if_unauthorized(response, endpoint: str):
+    """Check if the resposne returned with 401 unauthorized. Log as an error if not.
+
+    Parameters:
+    respone (request.response): response to HTTP request
+    endpoint (str): the endpoint that was hit during the request
+    """
     global failed
+    time.sleep(0.1)
     if not response.status_code == 401:
         failed += 1
         logging.debug("Got response: {}".format(response.status_code))
         logging.debug(response.content)
-        logging.error("Endpoint {0} is not secure".format(endpoint))
+        logging.error("Endpoint {0} is not secure ❌".format(endpoint))
+    else:
+        logging.info("Endpoint {0} is secure ✅".format(endpoint))
 
-def test_get(endpoint: str, token: str, params=''):
+def test_get(endpoint: str, token: str, params={}):
+    """Test an endpoint that uses a get REST request
+
+    Parameters:
+    endpoint (str): endpoint to test
+    token (str): auth token (JWT) for headers
+    params (dict): parameters for get request
+    """
     global tests
     tests += 1
     headers = get_header(token)
@@ -31,6 +59,12 @@ def test_get(endpoint: str, token: str, params=''):
     check_if_unauthorized(response, endpoint)
 
 def test_delete(endpoint: str, token: str):
+    """Test an endpoint that uses a delete REST request
+
+    Parameters:
+    endpoint (str): endpoint to test
+    token (str): auth token (JWT) for headers
+    """
     global tests
     tests += 1
     headers = get_header(token)
@@ -38,13 +72,41 @@ def test_delete(endpoint: str, token: str):
     response = requests.delete(url, headers=headers)
     check_if_unauthorized(response, endpoint)
 
-def test_post(endpoint: str, token: str, body=''):
+def test_post(endpoint: str, token: str, body={}):
+    """Test an endpoint that uses a post REST request
+
+    Parameters:
+    endpoint (str): endpoint to test
+    token (str): auth token (JWT) for headers
+    body (dict): NOT USED - body for the post request
+    """
     global tests
     tests += 1
     headers = get_header(token)
     url = '{0}{1}'.format(base_url, endpoint)
-    response = requests.post(url, data=body, headers=headers)
+    data = {}
+    # data['body'] = json.dumps(body)
+    response = requests.post(url, data=data, headers=headers)
     check_if_unauthorized(response, endpoint)
+
+def test_put(endpoint: str, token: str, body={}):
+    """Test an endpoint that uses a put REST request
+
+    Parameters:
+    endpoint (str): endpoint to test
+    token (str): auth token (JWT) for headers
+    body (dict): NOT USED - body for the post request
+    """
+    global tests
+    tests += 1
+    headers = get_header(token)
+    url = '{0}{1}'.format(base_url, endpoint)
+    data = {}
+    # data['body'] = json.dumps(body)
+    response = requests.put(url, data=data, headers=headers)
+    check_if_unauthorized(response, endpoint)
+
+######################### Test config #########################
 
 parser = argparse.ArgumentParser(description="Test security and authorization checks for Daily Dash backend.")
 parser.add_argument('--debug', action='store_true', default=False)
@@ -56,7 +118,8 @@ if args.debug:
 else:
     logging.getLogger().setLevel(logging.INFO)
 
-######################### Run tests
+######################### Run tests #########################
+# Note: Body has no effect, I could not get it working
 
 # users
 test_get('/users/{0}'.format(user_id), expired_token)
@@ -68,9 +131,13 @@ test_get('/goals'.format(user_id), expired_token)
 test_get('/goals/shortterm', expired_token)
 test_get('/goals/suggestedstg', expired_token)
 test_post('/goals', expired_token, body={'id': '123'})
+test_put('/goals/shortterm/counter', expired_token, body={'userId': user_id, 'shortTermGoalId': '23155198'})
 
+######################### Summary #########################
+
+logging.info("Testing complete.\n\n")
 logging.info("Total tests run: {}".format(tests))
 if failed > 0:
-    logging.error("Tests failed: {0}".format(failed))
+    logging.error("Tests failed: {0} ❌".format(failed))
 else:
-    logging.info("All tests passed! All are secure.")
+    logging.info("All tests passed! All are secure. ✅")

--- a/backend/test/authorizationTest.py
+++ b/backend/test/authorizationTest.py
@@ -1,0 +1,96 @@
+import json
+import requests
+import logging
+import argparse
+
+expired_token = "eyJhbGciOiJSUzI1NiIsImtpZCI6ImQxOTI5ZmY0NWM2MDllYzRjNDhlYmVmMGZiMTM5MmMzOTEzMmQ5YTEiLCJ0eXAiOiJKV1QifQ.eyJuYW1lIjoiTnlhIE1lbWVzIiwicGljdHVyZSI6Imh0dHBzOi8vbGg0Lmdvb2dsZXVzZXJjb250ZW50LmNvbS8tRzNfWng5VkZzbUUvQUFBQUFBQUFBQUkvQUFBQUFBQUFBQUEvQU1adXVjay1QSVlOdG4zTG1UZHlIM1hzVEthbTlTQVdSZy9zOTYtYy9waG90by5qcGciLCJpc3MiOiJodHRwczovL3NlY3VyZXRva2VuLmdvb2dsZS5jb20vZGFpbHlkYXNoLTZkOTc5IiwiYXVkIjoiZGFpbHlkYXNoLTZkOTc5IiwiYXV0aF90aW1lIjoxNjA0ODEwOTk2LCJ1c2VyX2lkIjoiVnRVaE1wMmF3YVBIOW1JcmxPSTNVQUR3Z2o3MyIsInN1YiI6IlZ0VWhNcDJhd2FQSDltSXJsT0kzVUFEd2dqNzMiLCJpYXQiOjE2MDQ4MTA5OTYsImV4cCI6MTYwNDgxNDU5NiwiZW1haWwiOiJueWFtZW1lc0BnbWFpbC5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiZmlyZWJhc2UiOnsiaWRlbnRpdGllcyI6eyJnb29nbGUuY29tIjpbIjEwNDk3NTg2MDUwOTcyNjIyNDU2MCJdLCJlbWFpbCI6WyJueWFtZW1lc0BnbWFpbC5jb20iXX0sInNpZ25faW5fcHJvdmlkZXIiOiJnb29nbGUuY29tIn19.not3iRfV3vruiAEkq9j4T4kIypofOIqW0sGw-DNaCbekkKYm7XuFHPP4YEZZD9Um7xyJT-IOzJ3yqW5jhumdjBwxMw72JmZ5hbt7m7OtQgtuwn-9Uxai0-P_6icSdUv1EVeO7apaI611QsxhpNwsq8x-sRQBgbmIfjpdXQ3rvPXTIsAUJirrR2-C-FRWEdbdo0sf63DRn-AUcAGPxHxijJRmE3jxRFQkXI5zRdZXFC-LP4ZjP3TvUg4poEPwM47uFaeBysa0aFQ3HN6wZVVqUpAQdspEOfRcq5NnOg2vX5ggB54DMtikK3UsDsj3vlGOrZsjQ7E2En3SCButv0ZUBw"
+user_id = 'RPeq88j3J7YPusoSsRcHg5rXepn1'
+base_url = "http://18.224.140.58:3000"
+
+failed = 0
+tests = 0
+
+def get_header(token: str):
+    return {'Content-Type': 'application/json',
+           'Authorization': 'Bearer {0}'.format(token)}
+
+def check_if_unauthorized(response, endpoint: str):
+    global failed
+    if not response.status_code == 401:
+        failed += 1
+        logging.debug("Got response: {}".format(response.status_code))
+        logging.debug(response.content)
+        logging.error("Endpoint {0} is not secure".format(endpoint))
+
+def test_get(endpoint: str, token: str, params=''):
+    global tests
+    tests += 1
+    headers = get_header(token)
+    url = '{0}{1}'.format(base_url, endpoint)
+    response = requests.get(url, params=params, headers=headers)
+    check_if_unauthorized(response, endpoint)
+
+def test_delete(endpoint: str, token: str):
+    global tests
+    tests += 1
+    headers = get_header(token)
+    url = '{0}{1}'.format(base_url, endpoint)
+    response = requests.delete(url, headers=headers)
+    check_if_unauthorized(response, endpoint)
+
+def test_post(endpoint: str, token: str, body=''):
+    global tests
+    tests += 1
+    headers = get_header(token)
+    url = '{0}{1}'.format(base_url, endpoint)
+    response = requests.post(url, data=body, headers=headers)
+    check_if_unauthorized(response, endpoint)
+
+parser = argparse.ArgumentParser(description="Test security and authorization checks for Daily Dash backend.")
+parser.add_argument('--debug', action='store_true', default=False)
+args = parser.parse_args()
+
+logging.basicConfig()
+if args.debug:
+    logging.getLogger().setLevel(logging.DEBUG)
+else:
+    logging.getLogger().setLevel(logging.INFO)
+
+######################### Run tests
+
+# users
+test_get('/users/{0}'.format(user_id), expired_token)
+test_delete('/users/{0}/notification?token=123456'.format(user_id), expired_token)
+test_post('/users', expired_token, body={'id': '123', 'email': 'ase@sfsf.com', 'username': 'bob', 'notificationId': 'notid'})
+
+# goals
+test_get('/goals'.format(user_id), expired_token)
+test_get('/goals/shortterm', expired_token)
+test_get('/goals/suggestedstg', expired_token)
+test_post('/goals', expired_token, body={'id': '123'})
+
+logging.info("Total tests run: {}".format(tests))
+if failed > 0:
+    logging.error("Tests failed: {0}".format(failed))
+else:
+    logging.info("All tests passed! All are secure.")
+
+
+
+
+# def test_endpoint(endpoint: str, method, token: str, body=None, params=None):
+#     global tests
+#     tests += 1
+#     headers = get_header(token)
+#     request_args = {}
+#     if body:
+#         request_args['body'] = body
+#     if params:
+#         request_args['params'] = params
+
+#     request_args['headers'] = headers
+
+#     url = '{0}{1}'.format(base_url, endpoint)
+#     response = method(url, request_args)
+#     check_if_unauthorized(response, endpoint)
+

--- a/backend/test/authorizationTest.py
+++ b/backend/test/authorizationTest.py
@@ -74,23 +74,3 @@ if failed > 0:
     logging.error("Tests failed: {0}".format(failed))
 else:
     logging.info("All tests passed! All are secure.")
-
-
-
-
-# def test_endpoint(endpoint: str, method, token: str, body=None, params=None):
-#     global tests
-#     tests += 1
-#     headers = get_header(token)
-#     request_args = {}
-#     if body:
-#         request_args['body'] = body
-#     if params:
-#         request_args['params'] = params
-
-#     request_args['headers'] = headers
-
-#     url = '{0}{1}'.format(base_url, endpoint)
-#     response = method(url, request_args)
-#     check_if_unauthorized(response, endpoint)
-


### PR DESCRIPTION
Added a python script which automatically tests the security of the endpoints on our server.

This works by sending an expired JWT and ensuring that the response has code 401 (unauthorized)