### PR TITLE
Add user time mode

### DIFF
--- a/backend/src/goals/goalsHelper.js
+++ b/backend/src/goals/goalsHelper.js
@@ -19,6 +19,7 @@ const getGoalsResponseFromDBResult = (result) => {
       var shortTermGoalObj = {
         id: shortTermGoal.id,
         title: shortTermGoal.title,
+        timesCompleted: shortTermGoal.timesCompleted,
         mon: shortTermGoal.mon,
         tue: shortTermGoal.tue,
         wed: shortTermGoal.wed,

--- a/backend/src/models/users.js
+++ b/backend/src/models/users.js
@@ -7,7 +7,7 @@ const User = new Schema({
     username: { type: String, required: true },
     notificationId: { type: String, required: true },
     goalsCompleted: { type: Number, default: 0 },
-    timeMode: { type: Number, default: 24 },
+    timeMode: { type: Number, default: 12 },
 });
 
 module.exports = mongoose.model("User", User);

--- a/backend/src/models/users.js
+++ b/backend/src/models/users.js
@@ -7,6 +7,7 @@ const User = new Schema({
     username: { type: String, required: true },
     notificationId: { type: String, required: true },
     goalsCompleted: { type: Number, default: 0 },
+    timeMode: { type: Number, default: 24 },
 });
 
 module.exports = mongoose.model("User", User);

--- a/backend/src/users/users.js
+++ b/backend/src/users/users.js
@@ -10,8 +10,9 @@ const addUser = async (req, res) => {
   const email = req.body.email;
   const username = req.body.username;
   const notificationId = req.body.notificationId;
+  const timeMode = req.body.timeMode;
 
-  if (id == null || email == null || username == null) {
+  if (id == null || email == null || username == null || notificationId == null || timeMode == null) {
     logger.info(`Missing parameters in ${req.body}`);
     res.status(400);
     res.end();
@@ -24,6 +25,7 @@ const addUser = async (req, res) => {
     username,
     notificationId,
     goalsCompleted: 0,
+    timeMode,
   };
 
   const query = {"userId": id};
@@ -61,7 +63,12 @@ const getUser = async (req, res) => {
       return;
     }
 
-    var response = {email: result.email, username: result.username};
+    var response = {
+      email: result.email, 
+      username: result.username,
+      goalsCompleted: result.goalsCompleted,
+      timeMode: result.timeMode
+    };
 
     res.send(response);
   } catch (error) {


### PR DESCRIPTION
Time mode can be set to 12/24 hr. Stored as Number in DB. Should be able to use the same endpoint to update it... I know we should have a seperate PUT endpoint, but I might add it later. For now it's fine because the call is idempotent. 

Example endpoints:
POST http://localhost:3000/users
```
{
	"id": "testUser3",
	"email": "sdff2",
	"username": "dff",
	"notificationId": "eysn1FN-RhGZ4ptNSqBZyR:APA91bGi5OqkOdoxRosRXmqU5WMEKObJbIdC5QgZQqKX9-BnspCi6LCAsrevL9bFU8pEQp0NXc8YwHVDCHAvTy2YP2C__PZgJX7E5zD7J3guQ9258CsmoMJAT93mQCRttfVIfIpgm56v",
	"timeMode": 24
}
```

GET http://localhost:3000/users/testUser3

```
Response:
{
  "email": "sdff2",
  "username": "dff",
  "goalsCompleted": 0,
  "timeMode": 24
}
```